### PR TITLE
Benchmark production-grade ways of loading templates in Django and Jinja2

### DIFF
--- a/microtemplates/benchmarks.py
+++ b/microtemplates/benchmarks.py
@@ -1,11 +1,12 @@
 import os
 import timeit
-from jinja2 import Template as JinjaTemplate
+from jinja2 import Environment, FileSystemLoader, Template as JinjaTemplate
 from django.conf import settings
 from django.template import Context, Template as DjangoTemplate
-from .base import Template as MicroTemplate
+from django.template.loaders.filesystem import Loader as DjangoDefaultLoader
+from django.template.loaders.cached import Loader as DjangoCachedLoader
+from base import Template as MicroTemplate
 
-settings.configure()
 
 template_dir = os.path.join(os.path.dirname(__file__), 'templates')
 context = {
@@ -17,6 +18,7 @@ context = {
     ]
 }
 
+settings.configure(TEMPLATE_DIRS=[template_dir])
 
 def read_html(engine):
     html_file_path = os.path.join(template_dir, "%s.html" % engine)
@@ -25,27 +27,45 @@ def read_html(engine):
     return html
 
 
+microtemplates_html = read_html('microtemplates')
+django_html = read_html('django')
+django_default_loader = DjangoDefaultLoader()
+django_cached_loader = DjangoCachedLoader(['django.template.loaders.filesystem.Loader'])
+jinja2_html = read_html('jinja2')
+jinja2_env = Environment(loader=FileSystemLoader(template_dir))
+
+
 def benchmark_microtemplates():
-    html = read_html('microtemplates')
-    MicroTemplate(html).render(**context)
+    MicroTemplate(microtemplates_html).render(**context)
 
 
 def benchmark_django():
-    html = read_html('django')
-    DjangoTemplate(html).render(Context(context))
+    DjangoTemplate(django_html).render(Context(context))
+
+
+def benchmark_django_default_loader():
+    template, _ = django_default_loader.load_template('django.html')
+    template.render(Context(context))
+
+
+def benchmark_django_cached_loader():
+    template, _ = django_cached_loader.load_template('django.html')
+    template.render(Context(context))
 
 
 def benchmark_jinja2():
-    html = read_html('jinja2')
-    JinjaTemplate(html).render(**context)
+    JinjaTemplate(jinja2_html).render(**context)
+
+
+def benchmark_jinja2_env():
+    jinja2_env.get_template('jinja2.html').render(**context)
 
 
 if __name__ == '__main__':
-    number = 1000
-    engines = ('microtemplates', 'django', 'jinja2')
+    number = 10000
+    engines = ('microtemplates', 'django', 'django_default_loader', 'django_cached_loader', 'jinja2', 'jinja2_env')
     setup = "from __main__ import %s" % ', '.join(map(lambda t: 'benchmark_' + t, engines))
     for engine in engines:
         t = timeit.Timer("benchmark_%s()" % engine, setup=setup)
         time = t.timeit(number=number) / number
         print "%s => run %s times, took %.2f ms" % (engine, number, 1000 * time)
-


### PR DESCRIPTION
Hey there!
Cool research project, good job. However, your benchmarks used some unrealistic ways of loading templates for Django and Jinja2. To make the comparison more apples-to-apples, I added some commonly used ways to load templates to `benchmarks.py`. Specifically:
- using Django's default template loader
- using Django's recommended caching loader
- using Jinja's `Environment` object

I also moved the file reading part away from other benchmarks so that we don't measure the speed of your storage.

The benchmarks with those are as follows on my machine:

```
microtemplates => run 10000 times, took 0.36 ms
django => run 10000 times, took 0.95 ms
django_default_loader => run 10000 times, took 1.16 ms
django_cached_loader => run 10000 times, took 0.46 ms
jinja2 => run 10000 times, took 5.64 ms
jinja2_env => run 10000 times, took 0.08 ms
```

Here, note the following: `microtemplates` are still faster than Django's cached loader, congratulations! The margin is much smaller, though. In case of Jinja2, the reason why your original method is so slow is that the data structures being built are optimized towards later reuse. Also in terms of generating helpful tracebacks when something in the template is actually wrong.
